### PR TITLE
Add full simulation demo with E.C.H.O. mock services

### DIFF
--- a/demos/full-mock/README.md
+++ b/demos/full-mock/README.md
@@ -1,0 +1,153 @@
+# D.A.W.N. Full Simulation Demo
+
+Run D.A.W.N.'s complete intent-processing pipeline without any external hardware, GPU, or API keys. All services are replaced by [E.C.H.O.](https://github.com/malcolmhoward/the-oasis-project-simulation-repo) simulation framework mocks.
+
+## What This Demonstrates
+
+The full "voice command to device control" loop:
+
+```
+User types in WebUI → D.A.W.N. sends to LLM mock → LLM returns tool call
+  → D.A.W.N. executes tool against HA mock → Entity state changes → Response
+```
+
+If you have used a voice assistant like Amazon Alexa or Google Assistant, this
+demo works on the same principle: recognized commands map to specific smart home
+actions, without any AI inference. The LLM mock uses keyword matching instead
+of a real model.
+
+## Requirements
+
+- Docker and Docker Compose
+- ~2 GB disk (D.A.W.N. build image)
+- No GPU, no API keys, no external services
+
+## Quick Start
+
+```bash
+# From the dawn repo root
+docker compose -f demos/full-mock/docker-compose.demo.yaml up --build
+```
+
+Then open D.A.W.N.'s WebUI in your browser:
+
+```bash
+# Linux
+xdg-open http://localhost:3000
+
+# macOS
+open http://localhost:3000
+
+# Windows
+start http://localhost:3000
+```
+
+## First Run — Create an Account
+
+D.A.W.N. requires creating an admin account before you can log in. On first
+launch, a one-time setup token is printed to the container logs. Use the
+`dawn-admin` CLI to create the account:
+
+```bash
+# 1. Find the setup token in the logs (valid for ~5 minutes after startup)
+docker logs full-mock-dawn-1 2>&1 | grep "Token:"
+# Output: ║   Token: DAWN-XXXX-XXXX-XXXX-XXXX
+
+# 2. Create the admin user (replace the token with yours)
+docker exec \
+  -e DAWN_SETUP_TOKEN=DAWN-XXXX-XXXX-XXXX-XXXX \
+  -e DAWN_PASSWORD=yourpassword \
+  full-mock-dawn-1 \
+  /opt/dawn/build/dawn-admin/dawn-admin user create admin --admin
+```
+
+Then log in at http://localhost:3000 with the username and password you chose.
+
+> **Note**: The setup token expires after ~5 minutes. If it expires, restart
+> the container (`docker restart full-mock-dawn-1`) to get a fresh token.
+
+The account is stored in a Docker volume (`dawn-data`) and persists across
+container restarts.
+
+## Tear Down
+
+```bash
+# Stop all containers
+docker compose -f demos/full-mock/docker-compose.demo.yaml down
+
+# Stop and remove the data volume (resets account and downloaded models)
+docker compose -f demos/full-mock/docker-compose.demo.yaml down -v
+```
+
+## Try These Commands
+
+Type in the WebUI chat:
+
+| Command | What Happens |
+|---------|-------------|
+| `hello` | Greeting with simulation mode info |
+| `turn on the kitchen lights` | LLM mock returns HA tool call → kitchen lights turn on |
+| `turn off the bedroom lights` | LLM mock returns HA tool call → bedroom lights turn off |
+| `set the thermostat` | LLM mock returns HA tool call → thermostat set to 22°C |
+| `what can you do` | Lists available simulation commands |
+| `what's the weather` | Default response (no rule matched) |
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     Docker Compose                           │
+│                                                              │
+│  ┌──────────────┐  ┌──────────────────┐  ┌──────────────┐  │
+│  │ mqtt-broker   │  │ mock-services    │  │    dawn      │  │
+│  │ (Mosquitto)   │  │                  │  │              │  │
+│  │ :1883         │  │ HA mock :8123    │  │ WebUI :3000  │  │
+│  │               │  │ LLM mock :8080   │  │              │  │
+│  └───────┬───────┘  └────────┬─────────┘  └──────┬───────┘  │
+│          │                   │                    │          │
+│          └───────────────────┼────────────────────┘          │
+│                    MQTT + HTTP (Docker network)              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Mock Services
+
+| Service | Port | What It Mocks | E.C.H.O. Class |
+|---------|------|---------------|----------------|
+| Home Assistant API | 8123 | Smart home entity control | `HomeAssistantMock` |
+| LLM API | 8080 | OpenAI-compatible `/v1/chat/completions` | `LLMMock` + `LLMHTTPServer` |
+| MQTT Broker | 1883 | Inter-component messaging | Eclipse Mosquitto (real) |
+
+### Default Entities (HA Mock)
+
+| Entity ID | Type | Initial State |
+|-----------|------|---------------|
+| `light.kitchen_lights` | Light | off |
+| `light.bedroom_lights` | Light | off |
+| `climate.living_room_thermostat` | Climate | heat (21°C) |
+
+## Adding Custom Skills
+
+Edit `mock_services/entrypoint.py` to add new voice command → tool call mappings:
+
+```python
+# Map a new voice command to an HA service call
+llm.add_tool_rule("lock the front door",
+    tool="homeassistant",
+    args={"action": "lock", "entity_id": "lock.front_door"})
+
+# Add a new entity to the HA mock
+ha.entities["lock.front_door"] = {
+    "entity_id": "lock.front_door",
+    "state": "unlocked",
+    "attributes": {"friendly_name": "Front Door Lock"},
+    "last_changed": "",
+    "last_updated": "",
+}
+```
+
+## Related
+
+- [E.C.H.O. Simulation Framework](https://github.com/malcolmhoward/the-oasis-project-simulation-repo) — Mock implementations
+- [M.I.R.A.G.E. HUD Demo](https://github.com/malcolmhoward/mirage/tree/feat/mirage/5-simulation-demo/demos/hud-mock) — HUD display with simulated sensors
+- [ADR-0003 Amendment 4](https://github.com/malcolmhoward/the-oasis-project-meta-repo) — Runtime injection and graceful degradation design

--- a/demos/full-mock/dawn-simulation.toml
+++ b/demos/full-mock/dawn-simulation.toml
@@ -1,0 +1,42 @@
+# D.A.W.N. configuration for full simulation mode.
+#
+# All external services are replaced by E.C.H.O. simulation framework mocks:
+#   - Home Assistant → HomeAssistantMock (Flask server on mock-ha:8123)
+#   - LLM → LLMMock wrapped in OpenAI-compatible HTTP server (mock-llm:8080)
+#   - MQTT → Mosquitto broker (mqtt-broker:1883)
+#
+# No GPU, no API keys, no external services required.
+
+[general]
+mode = "server"
+
+[llm]
+type = "local"
+
+[llm.local]
+endpoint = "http://mock-llm:8080"
+provider = "generic"
+model = "echo-mock"
+vision_enabled = false
+
+[llm.tools]
+mode = "native"
+
+[mqtt]
+enabled = true
+broker = "mqtt-broker"
+port = 1883
+tls = false
+
+[homeassistant]
+url = "http://mock-ha:8123"
+enabled = true
+
+[asr]
+model = "tiny.en"
+
+[memory]
+enabled = true
+
+[webui]
+port = 3000

--- a/demos/full-mock/docker-compose.demo.yaml
+++ b/demos/full-mock/docker-compose.demo.yaml
@@ -1,0 +1,67 @@
+# D.A.W.N. Full Simulation Demo
+#
+# Runs D.A.W.N. with all external services replaced by E.C.H.O. mocks.
+# No GPU, no API keys, no external services required.
+#
+# Usage:
+#   docker compose -f demos/full-mock/docker-compose.demo.yaml up --build
+#
+# Then open http://localhost:3000 to access D.A.W.N.'s WebUI.
+# Type in the chat: "turn on the kitchen lights" or "hello"
+
+services:
+  mqtt-broker:
+    image: eclipse-mosquitto:2
+    volumes:
+      - ./mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
+    ports:
+      - "1883:1883"
+    healthcheck:
+      test: ["CMD-SHELL", "mosquitto_sub -t '$$SYS/broker/uptime' -C 1 -W 3"]
+      interval: 5s
+      timeout: 3s
+      retries: 3
+
+  mock-services:
+    build:
+      context: ../..
+      dockerfile: demos/full-mock/mock_services/Dockerfile
+    environment:
+      - HA_PORT=8123
+      - LLM_PORT=8080
+    ports:
+      - "8123:8123"
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8080/v1/models')\""]
+      interval: 5s
+      timeout: 3s
+      retries: 3
+
+  dawn:
+    build:
+      context: ../..
+      dockerfile: Dockerfile.dev
+    volumes:
+      - ./dawn-simulation.toml:/opt/dawn/dawn.toml:ro
+      - ./secrets-simulation.toml:/opt/dawn/secrets.toml:ro
+      - dawn-data:/root/.local/share/dawn
+    ports:
+      - "3000:3000"
+    depends_on:
+      mqtt-broker:
+        condition: service_healthy
+      mock-services:
+        condition: service_healthy
+    environment:
+      - DAWN_GENERAL_MODE=server
+      - DAWN_LLM_TYPE=local
+      - DAWN_LLM_LOCAL_ENDPOINT=http://mock-services:8080
+      - DAWN_LLM_LOCAL_PROVIDER=generic
+      - DAWN_MQTT_BROKER=mqtt-broker
+      - DAWN_HOMEASSISTANT_URL=http://mock-services:8123
+      - SKIP_MODEL_DOWNLOAD=false
+      - WHISPER_MODEL=tiny.en
+
+volumes:
+  dawn-data:

--- a/demos/full-mock/mock_services/Dockerfile
+++ b/demos/full-mock/mock_services/Dockerfile
@@ -1,0 +1,15 @@
+# Mock services container — runs HomeAssistantMock and LLMHTTPServer
+# from the E.C.H.O. simulation framework.
+
+FROM python:3.12-slim
+
+WORKDIR /opt/mock-services
+
+# Install simulation framework
+COPY simulation_framework/ /opt/simulation_framework/
+RUN pip install --no-cache-dir -e "/opt/simulation_framework[all]"
+
+# Copy mock service entrypoints
+COPY demos/full-mock/mock_services/ /opt/mock-services/
+
+CMD ["python", "entrypoint.py"]

--- a/demos/full-mock/mock_services/entrypoint.py
+++ b/demos/full-mock/mock_services/entrypoint.py
@@ -1,0 +1,83 @@
+"""
+Mock services entrypoint — starts HomeAssistantMock and LLMHTTPServer
+for the D.A.W.N. simulation demo.
+
+Runs both services in the same container on different ports:
+  - HomeAssistantMock on port 8123 (HA REST API)
+  - LLMHTTPServer on port 8080 (OpenAI-compatible /v1/chat/completions)
+
+Environment variables:
+  HA_PORT (default 8123)
+  LLM_PORT (default 8080)
+"""
+
+import os
+import signal
+import sys
+import time
+
+from simulation.layer2.ha_mock import HomeAssistantMock
+from simulation.layer2.llm_mock import LLMMock
+from simulation.layer2.llm_http_server import LLMHTTPServer
+
+
+def main():
+    ha_port = int(os.environ.get("HA_PORT", "8123"))
+    llm_port = int(os.environ.get("LLM_PORT", "8080"))
+
+    # --- Home Assistant Mock ---
+    ha = HomeAssistantMock(host="0.0.0.0", port=ha_port)
+
+    # --- LLM Mock with smart home skills ---
+    llm = LLMMock(default_response="I'm not sure how to help with that. Try asking about the lights or thermostat.")
+
+    # Smart home tool calls — like Alexa skills, these map recognized
+    # voice commands to specific Home Assistant service calls.
+    llm.add_tool_rule("turn on the kitchen lights",
+        tool="homeassistant", args={"action": "turn_on", "entity_id": "light.kitchen_lights"})
+    llm.add_tool_rule("turn off the kitchen lights",
+        tool="homeassistant", args={"action": "turn_off", "entity_id": "light.kitchen_lights"})
+    llm.add_tool_rule("turn on the bedroom lights",
+        tool="homeassistant", args={"action": "turn_on", "entity_id": "light.bedroom_lights"})
+    llm.add_tool_rule("turn off the bedroom lights",
+        tool="homeassistant", args={"action": "turn_off", "entity_id": "light.bedroom_lights"})
+    llm.add_tool_rule("set thermostat",
+        tool="homeassistant", args={"action": "set_temperature", "entity_id": "climate.living_room_thermostat", "temperature": 22})
+
+    # Conversational responses for queries that don't trigger tool calls
+    llm.add_rule("hello", "Hey there! I'm DAWN running in simulation mode. Try asking me to turn on the lights.")
+    llm.add_rule("what can you do", "I can control your smart home devices. Try saying 'turn on the kitchen lights' or 'set the thermostat'.")
+    llm.add_rule("lights", "I can control the kitchen and bedroom lights. Say 'turn on the kitchen lights' or 'turn off the bedroom lights'.")
+    llm.add_rule("status", "All systems running in simulation mode. Home Assistant mock is active with kitchen lights, bedroom lights, and living room thermostat.")
+
+    llm_server = LLMHTTPServer(llm, host="0.0.0.0", port=llm_port)
+
+    # --- Start services ---
+    print(f"Starting HomeAssistantMock on port {ha_port}...")
+    ha.start()
+    print(f"Starting LLMHTTPServer on port {llm_port}...")
+    llm_server.start()
+
+    print(f"\nD.A.W.N. simulation services ready:")
+    print(f"  Home Assistant API: http://0.0.0.0:{ha_port}/api/states")
+    print(f"  LLM API:           http://0.0.0.0:{llm_port}/v1/chat/completions")
+    print(f"  LLM models:        http://0.0.0.0:{llm_port}/v1/models")
+    print(f"\nDefault entities: kitchen lights, bedroom lights, living room thermostat")
+    print(f"Try: 'turn on the kitchen lights', 'set the thermostat', 'hello'")
+
+    # --- Wait for shutdown signal ---
+    def shutdown(signum, frame):
+        print("\nShutting down mock services...")
+        llm_server.stop()
+        ha.stop()
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, shutdown)
+    signal.signal(signal.SIGINT, shutdown)
+
+    while True:
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/full-mock/mock_services/requirements.txt
+++ b/demos/full-mock/mock_services/requirements.txt
@@ -1,0 +1,3 @@
+flask>=3.0
+paho-mqtt>=1.6.1
+websockets>=11.0

--- a/demos/full-mock/mosquitto.conf
+++ b/demos/full-mock/mosquitto.conf
@@ -1,0 +1,2 @@
+listener 1883
+allow_anonymous true

--- a/demos/full-mock/secrets-simulation.toml
+++ b/demos/full-mock/secrets-simulation.toml
@@ -1,0 +1,11 @@
+# Secrets for simulation mode — no real API keys needed.
+#
+# The mock HA server accepts this token.
+# The mock LLM server requires no authentication.
+
+[secrets]
+mqtt_username = ""
+mqtt_password = ""
+
+[secrets.homeassistant]
+token = "mock-ha-token"


### PR DESCRIPTION
## Summary
Docker Compose demo that runs D.A.W.N.'s complete intent-processing pipeline without GPU, API keys, or external services:

- `HomeAssistantMock` (Flask) replaces real HA REST API
- `LLMMock` + `LLMHTTPServer` (OpenAI-compatible `/v1/chat/completions`) replaces real LLM
- Eclipse Mosquitto provides MQTT broker
- D.A.W.N. connects to mock URLs via `dawn-simulation.toml`

Demonstrates the "voice command → device control" loop: user types in WebUI → LLM mock keyword match → HA tool call → entity state change → response. Default skills: kitchen/bedroom lights on/off, thermostat control. Custom skills added by editing `entrypoint.py` (Alexa/Google-style keyword → action mapping).

## Type of Change
- [x] New feature
- [x] Documentation
- [ ] Bug fix
- [ ] Refactoring

## Testing
- [ ] `docker compose -f demos/full-mock/docker-compose.demo.yaml up --build` starts all services
- [ ] D.A.W.N. WebUI accessible at http://localhost:3000
- [ ] "turn on the kitchen lights" triggers LLM tool call → HA state change
- [ ] Mock services health checks pass

## Checklist
- [x] Documentation updated (demos/full-mock/README.md)
- [x] No breaking changes

**Stacked on**: PR #7 (deployment)
Closes #9
Tracked by: malcolmhoward/the-oasis-project-meta-repo#30 (simulation environment)

---
🤖 Generated with [Claude Code](https://claude.ai/code)
